### PR TITLE
Add support for python 3, and pip packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,114 @@
-.DS_Store
-venv
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
 .python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Other
+.DS_Store

--- a/bin/aws-profile-gpg
+++ b/bin/aws-profile-gpg
@@ -6,9 +6,12 @@ import sys
 
 import argparse
 try:
+    # Python 3
     import configparser
 except:
+    # Python 2
     import ConfigParser as configparser
+    import StringIO
 
 import botocore.session
 import gpgme
@@ -109,8 +112,14 @@ def main() :
     # make sure to read all of decrypted_bytes
     decrypted_bytes.seek(0)
 
-    credentials = ConfigParser.ConfigParser()
-    credentials.readfp( decrypted_bytes )
+    credentials = configparser.ConfigParser()
+    try:
+        # Python 3's configparser supports read_string
+        credentials.read_string( decrypted_string )
+    except:
+        # For Python 2, make the credentials file-like
+        buf = StringIO.StringIO( decrypted_string )
+        credentials.readfp( buf )
 
     if not credentials.has_section( source_profile ):
         sys.exit( 'Credentials file does not have source_profile "{}", AWS_PROFILE={}'.format(

--- a/bin/aws-profile-gpg
+++ b/bin/aws-profile-gpg
@@ -5,7 +5,10 @@ import os
 import sys
 
 import argparse
-import ConfigParser
+try:
+    import configparser
+except:
+    import ConfigParser as configparser
 
 import botocore.session
 import gpgme
@@ -37,16 +40,16 @@ def main() :
     profile          = str( os.getenv( 'AWS_PROFILE', os.getenv( 'AWS_DEFAULT_PROFILE', 'default' ) ) )
 
     if args.verbose:
-        print 'AWS_ENCRYPTED_CREDENTIALS_FILE={}'.format( credentials_file )
-        print 'AWS_CONFIG_FILE={}'.format( config_file )
-        print 'AWS_DEFAULT_PROFILE={}'.format( profile )
-        print 'command:', command
+        print('AWS_ENCRYPTED_CREDENTIALS_FILE={}'.format( credentials_file ))
+        print('AWS_CONFIG_FILE={}'.format( config_file ))
+        print('AWS_DEFAULT_PROFILE={}'.format( profile ))
+        print('command:', command)
 
     #
     # parse config
     #
 
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     config.read( os.path.expanduser( config_file ) )
 
     config_section = 'profile ' + profile
@@ -61,8 +64,8 @@ def main() :
         role_arn = config.get( config_section, 'role_arn' )
 
     if args.verbose:
-        print 'source_profile=' + str(source_profile)
-        print 'role_arn=' + str(role_arn)
+        print('source_profile=' + str(source_profile))
+        print('role_arn=' + str(role_arn))
 
     #
     # read encrypted file
@@ -146,7 +149,7 @@ def main() :
         sys.exit( 'Profile not found in config; profile={}'.format( profile ) )
 
     if args.verbose:
-        print 'AWS_DEFAULT_REGION={}'.format( region )
+        print('AWS_DEFAULT_REGION={}'.format( region ))
 
     #
     # switch iam roles using sts
@@ -167,7 +170,7 @@ def main() :
         role_credentials = assumed_role_object['Credentials']
 
         if args.verbose:
-            print role_credentials
+            print(role_credentials)
 
         os.putenv( 'AWS_ACCESS_KEY_ID', role_credentials['AccessKeyId'] )
         os.putenv( 'AWS_SECRET_ACCESS_KEY', role_credentials['SecretAccessKey'] )
@@ -178,7 +181,7 @@ def main() :
     #
 
     if args.verbose:
-        print 'Command output:'
+        print('Command output:')
 
     my_env = os.environ.copy()
     command_status = os.system( command )

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ from distutils.core import setup
 setup(
     name='aws-profile-gpg',
     version='0.0.1',
+    author="jeff oconnell",
+    author_email="jeff.oconnell@firstlook.media",
+    license="MIT",
 
     url='https://github.com/jefforulez/aws-profile-gpg',
 
@@ -17,5 +20,14 @@ setup(
     install_requires=[
        'botocore>=1.4,<2',
        'PyGPGME>=0.3,<1',
-    ]
+    ],
+
+    classifiers=(
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Security :: Cryptography",
+        "Topic :: System :: Systems Administration"
+    )
 )


### PR DESCRIPTION
This PR adds a more robust `.gitignore` file (github's default for python projects), adds a bunch of new fields to the `setup.py` file, and makes a few small changes to add support for python 3 (python 2 should still work, but please make sure).

You've already packaged `aws-profile-gpg` to homebrew, but if you want to also package it in PyPi, Linux users like me will be able to install it from pip. Here are instructions if you're interested: https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives